### PR TITLE
Add card color to all card exports as well as the exported images

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,12 +14,13 @@
       <artifactId>slaythespire</artifactId>
       <version>016</version>
       <scope>system</scope>
-      <systemPath>${basedir}/../_ModTheSpire/desktop-1.0.jar</systemPath>
+      <!-- Replace this with wherever this file is on your machine. -->
+      <systemPath>/home/vesper-arch/.local/share/Steam/steamapps/common/SlayTheSpire/desktop-1.0.jar</systemPath>
     </dependency>
     <dependency>
       <groupId>org.jtwig</groupId>
       <artifactId>jtwig-core</artifactId>
-      <version>5.85.0.RELEASE</version>
+      <version>5.87.0.RELEASE</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -27,14 +28,16 @@
       <artifactId>BaseMod</artifactId>
       <version>1.6.5</version>
       <scope>system</scope>
-      <systemPath>${basedir}/../_ModTheSpire/mods/BaseMod.jar</systemPath>
+      <!-- Replace this with the path for where BaseMod is on your machine. -->
+      <systemPath>/home/vesper-arch/.local/share/Steam/steamapps/workshop/content/646570/1605833019/BaseMod.jar</systemPath>
     </dependency>
     <dependency>
       <groupId>modthespire</groupId>
       <artifactId>ModTheSpire</artifactId>
       <version>2.4.0</version>
       <scope>system</scope>
-      <systemPath>${basedir}/../_ModTheSpire/ModTheSpire.jar</systemPath>
+      <!-- Replace this with the path for where ModTheSpire is on your machine. -->
+      <systemPath>/home/vesper-arch/.local/share/Steam/steamapps/workshop/content/646570/1605060445/ModTheSpire.jar</systemPath>
     </dependency>
   </dependencies>
 

--- a/src/main/java/sts_exporter/CardExportData.java
+++ b/src/main/java/sts_exporter/CardExportData.java
@@ -91,8 +91,8 @@ public class CardExportData implements Comparable<CardExportData> {
                             .replace(" NL ", "\n");
         }
         // image
-        this.image = export.exportPath(this.mod, "card-images", this.name, ".png");
-        this.smallImage = export.exportPath(this.mod, "small-card-images", this.name, ".png");
+        this.image = export.exportPath(this.mod, "card-images", this.color+"-"+this.name, ".png");
+        this.smallImage = export.exportPath(this.mod, "small-card-images", this.color+"-"+this.name, ".png");
     }
 
     public void exportImages() {

--- a/src/main/java/sts_exporter/ExportHelper.java
+++ b/src/main/java/sts_exporter/ExportHelper.java
@@ -102,9 +102,9 @@ class ExportHelper {
         }
     }
 
-    private static final String[] colorTemplates = {"cards.html","cards.md","cards.wiki","wiki-card-data.txt","style.css"};
+    private static final String[] colorTemplates = {"cards.html","cards.md","cards.lua","cards.wiki","wiki-card-data.txt","style.css"};
     private static final String[] indexTemplates = {"index.html","wiki-card-data.txt"};
-    private static final String[] commonTemplates = {"creatures.html","keywords.html","potions.html","relics.html","cards.html","creatures.md","keywords.md","potions.md","relics.md","cards.md","items.json","style.css"};
+    private static final String[] commonTemplates = {"creatures.html","keywords.html","potions.html","relics.html","cards.html","creatures.md","keywords.md","potions.md","relics.md","cards.md","cards.lua","relics.lua","items.json","style.css"};
     private static final String[] modTemplates = {"index.html","index.md"};
 
     void exportAllTemplates() {

--- a/src/main/resources/templates/cards.lua.twig
+++ b/src/main/resources/templates/cards.lua.twig
@@ -1,0 +1,13 @@
+return {
+    {% for card in cards
+    %}["{{ escape(card.name, 'js') }}"] = {
+        Image = "{{ card.image.relativeTo(dir) }}",
+        Color = "{{ card.color }}",
+        Rarity = "{{ card.rarity }}",
+        Type = "{{ card.type }}",
+        Cost = {{ card.card.cost }},{% if card.cost != card.upgrade.cost %}
+        CostPlus = {{ card.upgrade.card.cost }},{% endif %}
+        Description = "{{ escape(card.textWikiData,'js') }}",
+    },
+    {% endfor %}
+}

--- a/src/main/resources/templates/cards.md.twig
+++ b/src/main/resources/templates/cards.md.twig
@@ -1,5 +1,5 @@
-| Name | Image | Upgraded image | Rarity | Type | Cost | Description |
-| ---- | ----- | -------------- | ------ | ---- | ---- | ----------- |
+| Name | Image | Upgraded image | Color | Rarity | Type | Cost | Description |
+| ---- | ----- | -------------- | ----- | ------ | ---- | ---- | ----------- |
 {% for card in cards
-%}| {{ card.name }} | ![]({{ card.smallImage.relativeTo(dir) }}) | ![]({{ card.upgrade.smallImage.relativeTo(dir) }}) | {{ card.rarity }} | {{ card.type }} | {{ card.costAndUpgrade }} | {{ card.textAndUpgrade | replace({'\n':' '}) }} |
+%}| {{ card.name }} | ![]({{ card.smallImage.relativeTo(dir) }}) | ![]({{ card.upgrade.smallImage.relativeTo(dir) }}) | {{ card.color }} | {{ card.rarity }} | {{ card.type }} | {{ card.costAndUpgrade }} | {{ card.textAndUpgrade | replace({'\n':' '}) }} |
 {% endfor %}

--- a/src/main/resources/templates/cards.wiki.twig
+++ b/src/main/resources/templates/cards.wiki.twig
@@ -4,6 +4,7 @@
 |-
 !Name
 !Picture
+!Color
 !Rarity
 !Type
 !Energy
@@ -11,6 +12,7 @@
 |-{% for card in cards %}
 |[[{{ card.name }}]]
 |[[File:{{ card.image.file }}|thumb|289x289px]]
+|{{ card.color }}
 |{{ card.rarity }}
 |[[{{ card.type }}]]
 |{{ card.costAndUpgrade }}

--- a/src/main/resources/templates/fragments/cards.html.twig
+++ b/src/main/resources/templates/fragments/cards.html.twig
@@ -3,6 +3,7 @@
     <th>Name</th>
     <th>Image</th>
     <th>Upgraded image</th>
+    <th>Color</th>
     <th>Rarity</th>
     <th>Type</th>
     <th>Cost</th>
@@ -14,6 +15,7 @@
     <td>{{ card.name }}</td>
     <td><a href="{{ card.image.relativeTo(dir) }}"><img src="{{ card.smallImage.relativeTo(dir) }}" height="298"></a></td>
     <td>{% if card.upgrade %}<a href="{{ card.upgrade.image.relativeTo(dir) }}"><img src="{{ card.upgrade.smallImage.relativeTo(dir) }}" height="298"></a>{% endif %}</td>
+    <td>{{ card.color }}</td>
     <td>{{ card.rarity }}</td>
     <td>{{ card.type }}</td>
     <td>{{ card.costAndUpgrade }}</td>

--- a/src/main/resources/templates/potions.lua.twig
+++ b/src/main/resources/templates/potions.lua.twig
@@ -1,0 +1,10 @@
+return {
+    {% for potion in potions
+    %}["{{ potion.name }}"] = {
+        Image = "{{ potion.image.relativeTo(dir) }}",
+        Character = "",
+        Rarity = "{{ potion.rarity }}",
+
+    },
+    {% endfor %}
+}

--- a/src/main/resources/templates/potions.md.twig
+++ b/src/main/resources/templates/potions.md.twig
@@ -1,5 +1,5 @@
-| Image | Name | Rarity | Description |
-| ----- | ---- | ------ | ----------- |
+| Image | Name | Character | Rarity | Description |
+| ----- | ---- | --------- | ------ | ----------- |
 {% for potion in potions
-%}| ![]({{ potion.image.relativeTo(dir) }}) | {{ potion.name }} | {{ potion.rarity }} | {{ potion.descriptionPlain | replace({'\n':' '}) }} |
+%}| ![]({{ potion.image.relativeTo(dir) }}) | {{ potion.name }} | {{ potion.playerClass }} | {{ potion.rarity }} | {{ potion.descriptionPlain | replace({'\n':' '}) }} |
 {% endfor %}

--- a/src/main/resources/templates/relics.lua.twig
+++ b/src/main/resources/templates/relics.lua.twig
@@ -1,0 +1,11 @@
+return {
+    {% for relic in relics
+    %}["{{ relic.name }}"] = {
+        Image = "{{ relic.image.relativeTo(dir) }}",
+        Rarity = "{{ relic.tier }}",
+        Character = "{{ relic.pool }}",
+        Description = "{{ relic.description | replace({'\n':'<br>'}) }}",
+        Flavor = "{{ relic.flavorTextPlain | replace({'\n':'<br>'}) }}"
+    },
+    {% endfor %}
+}

--- a/src/main/resources/templates/wiki-card-data.txt.twig
+++ b/src/main/resources/templates/wiki-card-data.txt.twig
@@ -7,5 +7,4 @@
     Cost = {{ card.card.cost }},{% if card.cost != card.upgrade.cost %}
     CostPlus = {{ card.upgrade.card.cost }},{% endif %}
     Text = "{{ escape(card.textWikiData,'js') }}",
-    Traits = {},
     },{% endfor %}


### PR DESCRIPTION
Color was missing from the markdown, html, and wiki formats for card exports. Color is added to the file names also so cards with the same name (i.e character specific strike and defend cards) are still exported.